### PR TITLE
feat: basic timeout support

### DIFF
--- a/config/default.json5
+++ b/config/default.json5
@@ -1,8 +1,13 @@
 {
   db: 'db.sqlite',
   ipfs: {
-    // The default value for go-ipfs
-    connection: '/ip4/127.0.0.1/tcp/5001',
+    clientOptions: {
+      // The default value for go-ipfs
+      url: 'http://localhost:5001',
+    },
+
+    // What is timeout for fetching size of given hash
+    sizeFetchTimeout: '4m'
   },
   blockchain: {
     // Events that will be listened to

--- a/config/development.json5
+++ b/config/development.json5
@@ -4,5 +4,8 @@
     eventsEmitter: {
       confirmations: 1
     }
+  },
+  ipfs: {
+    sizeFetchTimeout: '30s'
   }
 }

--- a/src/@types/ipfs-http-client/index.d.ts
+++ b/src/@types/ipfs-http-client/index.d.ts
@@ -11,7 +11,7 @@ declare module 'ipfs-http-client' {
   export type CidAddress = CID | Buffer | string
 
   interface Options {
-    timeout?: number
+    timeout?: number | string
     headers?: object
     signal?: any
   }
@@ -137,12 +137,14 @@ declare module 'ipfs-http-client' {
   }
 
   export interface ClientOptions {
-    host: string
-    port: number
-    protocol: string
-    'api-path': string
-    'user-agent': string
-    headers: object
+    url?: string
+    host?: string
+    port?: number
+    protocol?: string
+    'api-path'?: string
+    'user-agent'?: string
+    headers?: object
+    timeout?: number | string
   }
 
   export default function ipfsClient (hostOrMultiaddr?: multiaddr | ClientOptions | string, port?: Port | string, userOptions?: ClientOptions): IpfsClient

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -77,7 +77,7 @@ and when there is new Agreement for specified Offer it will pin the content to y
     }
 
     if (flags.ipfs) {
-      configObject.ipfs = { connection: flags.ipfs }
+      configObject.ipfs = { clientOptions: { url: flags.ipfs } }
     }
 
     if (flags.config) {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -3,6 +3,8 @@
  */
 import type { EventData } from 'web3-eth-contract'
 import type { Eth } from 'web3-eth'
+import type { ClientOptions as IpfsOptions } from 'ipfs-http-client'
+
 import type { ProviderManager } from './providers'
 
 export enum Providers {
@@ -10,8 +12,8 @@ export enum Providers {
 }
 
 export interface Provider {
-  pin(hash: string, expectedSize: number): Promise<void>
-  unpin(hash: string): Promise<void>
+  pin (hash: string, expectedSize: number): Promise<void>
+  unpin (hash: string): Promise<void>
 }
 
 export interface Logger {
@@ -75,8 +77,8 @@ export interface Config {
   }
 
   ipfs?: {
-    // URL to the IPFS running node
-    connection?: string
+    clientOptions?: IpfsOptions
+    sizeFetchTimeout?: number | string
   }
 
   log?: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import { ProviderManager } from './providers'
 import { IpfsProvider } from './providers/ipfs'
 import { AppOptions } from './definitions'
 import { collectPinsClosure } from './gc'
-import { errorHandler } from './utils'
+import { duplicateObject, errorHandler } from './utils'
 
 export default async (offerId: string, options?: AppOptions): Promise<{ stop: () => void }> => {
   const logger = loggingFactory()
@@ -36,7 +36,7 @@ export default async (offerId: string, options?: AppOptions): Promise<{ stop: ()
   const store = getObject()
 
   const manager = new ProviderManager()
-  const ipfs = await IpfsProvider.bootstrap(config.get<string>('ipfs.connection'))
+  const ipfs = await IpfsProvider.bootstrap(duplicateObject(config.get<string>('ipfs.clientOptions')), config.get<number|string>('ipfs.sizeFetchTimeout'))
   manager.register(ipfs)
 
   const eth = ethFactory()

--- a/src/providers/ipfs.ts
+++ b/src/providers/ipfs.ts
@@ -10,12 +10,14 @@ const REQUIRED_IPFS_VERSION = '>=0.5.0'
 
 export class IpfsProvider implements Provider {
   private readonly ipfs: IpfsClient
+  private readonly statTimeout?: number | string
 
-  constructor (ipfs: IpfsClient) {
+  constructor (ipfs: IpfsClient, statTimeout?: number | string) {
     this.ipfs = ipfs
+    this.statTimeout = statTimeout
   }
 
-  static async bootstrap (options?: ClientOptions | string): Promise<IpfsProvider> {
+  static async bootstrap (options?: ClientOptions | string, statTimeout?: number | string): Promise<IpfsProvider> {
     if (!options) {
       // Default location of local node, lets try that one
       options = '/ip4/127.0.0.1/tcp/5001'
@@ -38,7 +40,7 @@ export class IpfsProvider implements Provider {
       throw new Error(`Supplied IPFS node is version ${versionObject.version} while this utility requires version ${REQUIRED_IPFS_VERSION}`)
     }
 
-    return new this(ipfs)
+    return new this(ipfs, statTimeout)
   }
 
   /**
@@ -51,16 +53,29 @@ export class IpfsProvider implements Provider {
   async pin (hash: string, expectedSize: number): Promise<void> {
     hash = hash.replace('/ipfs/', '')
     const cid = new CID(hash)
-    const stats = await this.ipfs.object.stat(cid)
 
-    if (stats.CumulativeSize > expectedSize) {
-      logger.error(`The hash ${hash} has cumulative size of ${stats.CumulativeSize} bytes while it was expected to have ${expectedSize} bytes.`)
-      throw new Error('The hash exceeds payed size!')
+    logger.verbose(`Retrieving size of CID ${hash}`)
+    try {
+      const stats = await this.ipfs.object.stat(cid, { timeout: this.statTimeout })
+
+      if (stats.CumulativeSize > expectedSize) {
+        logger.error(`The hash ${hash} has cumulative size of ${stats.CumulativeSize} bytes while it was expected to have ${expectedSize} bytes.`)
+        throw new Error('The hash exceeds payed size!')
+      }
+    } catch (e) {
+      if (e.name === 'TimeoutError') {
+        logger.error(`Fetching size of ${hash} timed out!`)
+        return // Since we can't validate the size we won't pin it! Most probably the file is not in the network.
+      } else {
+        throw e
+      }
     }
 
     const start = process.hrtime()
     logger.info(`Pinning hash: ${hash} start`)
-    await this.ipfs.pin.add(cid)
+    // TODO: For this call there is applied the default 20 minutes timeout. This should be estimated using the size.
+    //  https://github.com/ipfs/js-ipfs/blob/master/packages/ipfs-http-client/src/lib/core.js#L113
+    await this.ipfs.pin.add(cid) // The data can be big and we don't want to automatically timeout here.
     logger.info(`Pinning hash: ${hash} ended in ${process.hrtime(start)[0]}s`)
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -39,3 +39,7 @@ export function decodeByteArray (fileReference: string[]): string {
     .trim()
     .replace(/\0/g, '') // Remove null-characters
 }
+
+export function duplicateObject<T> (obj: T): T {
+  return JSON.parse(JSON.stringify(obj))
+}


### PR DESCRIPTION
Currently if the CID is not in network the `object.stats()` call will hang until default time-out (20 minutes). This is problematic for `precache` since the service won't start until all precache & pinning is finished.

This solves it with configurable timeout. If it timesout than pinning of the file is canceled as it is most probably not in the network.

This will be improved upon with #63 