### PR TITLE
feat: basic communication interface

### DIFF
--- a/src/communication.ts
+++ b/src/communication.ts
@@ -1,0 +1,35 @@
+import { loggingFactory } from './logger'
+
+const logger = loggingFactory('coms')
+
+export enum MESSAGE_CODE {
+  I_GENERAL = 0,
+  I_AGREMENT_NEW = 1,
+  I_AGREMENT_EXPIRED = 2,
+  I_AGREMENT_RENEWED = 3,
+  I_HASH_NEW = 4,
+  I_HASH_DOWNLOADED = 5,
+  E_GENERAL = 100,
+  E_HASH_NOT_FOUND = 101,
+  E_AGREEMENT_SIZE_LIMIT_EXCEEDED = 102
+}
+
+class Communication {
+  private static instance: Communication;
+  private constructor () {} // eslint-disable-line
+
+  static getInstance () {
+    if (!Communication.instance) {
+      Communication.instance = new Communication()
+    }
+    return Communication.instance
+  }
+
+  broadcast (code: MESSAGE_CODE, payload?: Record<string, any>) {
+    logger.error(`NOT IMPLEMENTED - broadcasting message with code ${code}`, payload)
+  }
+}
+
+const instance = Communication.getInstance()
+
+export default instance


### PR DESCRIPTION
Just a basic interface for the comms system so that I don't block anyone as I over-engineer the solution. Usage:

```
import communication, { MESSAGE_CODE } from './communication'

communication.broadcast(MESSAGE_CODE.I_AGREMENT_NEW)

communication.broadcast(MESSAGE_CODE.E_GENERAL, {message: "Unknown error, but we sent an astronaut to investigate" })
```