### PR TITLE
Release 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+<a name="0.2.1"></a>
+## [0.2.1](https://github.com/rsksmart/rds-ipfs/compare/v0.2.0...v0.2.1) (2021-02-01)
+
+
+
 <a name="0.2.0"></a>
 # [0.2.0](https://github.com/rsksmart/rds-ipfs/compare/v0.1.2...v0.2.0) (2021-01-21)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rif-storage-pinning",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Application for providing your storage space to other to use in exchange of RIF Tokens",
   "keywords": [
     "IPFS",


### PR DESCRIPTION
<a name="0.2.1"></a>
## [0.2.1](https://github.com/rsksmart/rds-ipfs/compare/v0.2.0...v0.2.1) (2021-02-01)
 - Update web3-events lib