### PR TITLE
chore: fix log injection

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -143,11 +143,12 @@ function initLogging (): void {
   })
 }
 
-export function formatLogMessage(info: any): string {
+export function formatLogMessage (info: any): string {
   let message: string
   const { service, ...rest } = info.metadata
 
   const sanitizedMessage = info.message.replace(/\n/g, '\\n')
+
   if (service) {
     message = `[${info.level}] ${colors.grey(info.timestamp)} (${service}): ${sanitizedMessage}`
   } else {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -136,26 +136,29 @@ function initLogging (): void {
       // format.padLevels(),
       format.timestamp({ format: 'DD/MM hh:mm:ss' }),
       format.colorize(),
-      format.printf(info => {
-        let message: string
-        const { service, ...rest } = info.metadata
-
-        if (service) {
-          message = `[${info.level}] ${colors.grey(info.timestamp)} (${service}): ${info.message}`
-        } else {
-          message = `[${info.level}] ${colors.grey(info.timestamp)}: ${info.message}`
-        }
-
-        if (Object.keys(rest).length > 0) {
-          message += '\n' + inspect(rest, false, 5, true)
-        }
-
-        return message
-      }),
+      format.printf(formatLogMessage),
       COLORS_ENABLED ? format(i => i)() : format.uncolorize()
     ),
     transports: transportsSet
   })
+}
+
+export function formatLogMessage(info: any): string {
+  let message: string
+  const { service, ...rest } = info.metadata
+
+  const sanitizedMessage = info.message.replace(/\n/g, '\\n')
+  if (service) {
+    message = `[${info.level}] ${colors.grey(info.timestamp)} (${service}): ${sanitizedMessage}`
+  } else {
+    message = `[${info.level}] ${colors.grey(info.timestamp)}: ${sanitizedMessage}`
+  }
+
+  if (Object.keys(rest).length > 0) {
+    message += '\n' + inspect(rest, false, 5, true)
+  }
+
+  return message
 }
 
 function delayedLoggingMethod (level: SupportedLevels, name?: string) {

--- a/test/unit/logger.spec.ts
+++ b/test/unit/logger.spec.ts
@@ -8,14 +8,14 @@ const expect = chai.expect
 
 describe('Logger test', () => {
   it('should log the message as it is', () => {
-    const timestamp = Date().toLocaleString();
+    const timestamp = Date().toLocaleString()
     const message = formatLogMessage({ level: 'ERROR', message: 'Nasty error is here', timestamp, metadata: { service: 'db' } })
     const expectedMessage = `[ERROR] ${colors.grey(timestamp)} (db): Nasty error is here`
     expect(message).to.be.eql(expectedMessage)
   })
 
   it('should sanitize invalid log entry', () => {
-    const timestamp = Date().toLocaleString();
+    const timestamp = Date().toLocaleString()
     const message = formatLogMessage({ level: 'ERROR', message: `Nasty error is here\n[ERROR] ${colors.grey(timestamp)} (user): bad guy logged out`, timestamp, metadata: { service: 'db' } })
     const expectedMessage = `[ERROR] ${colors.grey(timestamp)} (db): Nasty error is here\\n[ERROR] ${colors.grey(timestamp)} (user): bad guy logged out`
     expect(message).to.be.eql(expectedMessage)

--- a/test/unit/logger.spec.ts
+++ b/test/unit/logger.spec.ts
@@ -1,0 +1,23 @@
+import chai from 'chai'
+import sinonChai from 'sinon-chai'
+import colors from 'colors/safe'
+import { formatLogMessage } from '../../src/logger'
+
+chai.use(sinonChai)
+const expect = chai.expect
+
+describe('Logger test', () => {
+  it('should log the message as it is', () => {
+    const timestamp = Date().toLocaleString();
+    const message = formatLogMessage({ level: 'ERROR', message: 'Nasty error is here', timestamp, metadata: { service: 'db' } })
+    const expectedMessage = `[ERROR] ${colors.grey(timestamp)} (db): Nasty error is here`
+    expect(message).to.be.eql(expectedMessage)
+  })
+
+  it('should sanitize invalid log entry', () => {
+    const timestamp = Date().toLocaleString();
+    const message = formatLogMessage({ level: 'ERROR', message: `Nasty error is here\n[ERROR] ${colors.grey(timestamp)} (user): bad guy logged out`, timestamp, metadata: { service: 'db' } })
+    const expectedMessage = `[ERROR] ${colors.grey(timestamp)} (db): Nasty error is here\\n[ERROR] ${colors.grey(timestamp)} (user): bad guy logged out`
+    expect(message).to.be.eql(expectedMessage)
+  })
+})


### PR DESCRIPTION
Affected Assets
https://github.com/rsksmart/rif-storage-pinner/releases/tag/v0.2.1

Description
Log Injection (also known as Log Forging) is a vulnerability where an attacker can forge new log entries, due to a bad input sanitisation by the application.

Remediation
All external data should be sanitised before sending it to logs.

When using a simple one line per entry format for the logs, new lines characters should be removed or escaped so that an attacker cannot create new entries.

References
https://owasp.org/www-community/attacks/Log_Injection

https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html

https://thesecurityvault.com/appsec/log-forging-vulnerability-and-how-to-fix-it/