### PR TITLE
Release 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+<a name="0.2.2"></a>
+## [0.2.2](https://github.com/rsksmart/rds-ipfs/compare/v0.2.1...v0.2.2) (2021-03-04)
+
+* update `@rsksmart/rif-marketplace-storage` to `0.1.0`
+
 <a name="0.2.1"></a>
 ## [0.2.1](https://github.com/rsksmart/rds-ipfs/compare/v0.2.0...v0.2.1) (2021-02-01)
 

--- a/config/staging.json5
+++ b/config/staging.json5
@@ -20,7 +20,7 @@
     contractAddress: '0xaF37117a4907331DC49b05bDC1DE920F12dBF715',
     networkId: 31,
     eventsEmitter: {
-      startingBlock: 1333889,
+      startingBlock: 1656755,
       confirmations: 3
     }
   }

--- a/config/testnet.json5
+++ b/config/testnet.json5
@@ -20,7 +20,7 @@
     contractAddress : '0x839856c0eC1aA2AeD25D47Fd3DDB7A14Dac3e76d',
     networkId: 31,
     eventsEmitter: {
-      startingBlock: 1425147,
+      startingBlock: 1656800,
       confirmations: 8
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rif-storage-pinning",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Application for providing your storage space to other to use in exchange of RIF Tokens",
   "keywords": [
     "IPFS",

--- a/package.json
+++ b/package.json
@@ -124,9 +124,10 @@
   "types": "types/index.d.ts",
   "contributors": [
     "Adam Uhlíř <adam@uhlir.dev>",
+    "Artem B <artem.bv@protonmail.com>",
     "Julian M. Rodriguez <56316686+julianmrodri@users.noreply.github.com>",
-    "Nazar Duchak <41945483+nduchak@users.noreply.github.com>",
     "Nazar Duchak <nazar@iovlabs.org>",
+    "Nazar Duchak <41945483+nduchak@users.noreply.github.com>",
     "Vojtech Simetka <vojtech@simetka.cz>",
     "dependabot-preview[bot] <27856297+dependabot-preview[bot]@users.noreply.github.com>"
   ],


### PR DESCRIPTION
<a name="0.2.2"></a>
## [0.2.2](https://github.com/rsksmart/rds-ipfs/compare/v0.2.1...v0.2.2) (2021-03-04)

* update `@rsksmart/rif-marketplace-storage` to `0.1.0`
